### PR TITLE
Fix build for Mac and Xcode 5.

### DIFF
--- a/include/internal/iutest_compiler.hpp
+++ b/include/internal/iutest_compiler.hpp
@@ -48,9 +48,9 @@
 #  endif
 #elif	defined(__APPLE__)
 #  include "TargetConditionals.h"
-#  ifdef TARGET_OS_IPHONE
+#  if TARGET_OS_IPHONE
 #    define IUTEST_OS_IOS				1
-#    ifdef TARGET_IPHONE_SIMULATOR
+#    if TARGET_IPHONE_SIMULATOR
 #      define IUTEST_OS_IOS_SIMULATOR	1
 #      define IUTEST_PLATFORM			"iOS Simulator"
 #    else

--- a/include/internal/iutest_port.hpp
+++ b/include/internal/iutest_port.hpp
@@ -25,7 +25,7 @@
 
 #include "iutest_internal_defs.hpp"
 
-#if defined(IUTEST_OS_LINUX) || defined(IUTEST_OS_CYGWIN)
+#if defined(IUTEST_OS_LINUX) || defined(IUTEST_OS_CYGWIN) || defined(IUTEST_OS_MAC)
 #  include <unistd.h>
 #  include <locale.h>
 #endif


### PR DESCRIPTION
Mac デスクトップ向けアプリケーションに iutest を使用できるよう修正しました。
修正した内容は 2 つです。
### iOS アプリケーションと認識される

Mac 向けのアプリケーションにて、`IUTEST_OS_MAC` ではなく iOS アプリケーションを示す `IUTEST_OS_IOS` と `IUTEST_OS_IOS_SIMULATOR` が定義されていました。

`iutest_compiler.hpp` の該当箇所を次のように変更し、`IUTEST_OS_MAC` と `IUTEST_PLATFORM="Mac OS"` が定義されることを確認しました:
- `#ifdef TARGET_OS_IPHONE` を `#if TARGET_OS_IPHONE` に置換
- 同様に `#ifdef TARGET_IPHONE_SIMULATOR` を `#if TARGET_IPHONE_SIMULATOR` に置換
### `getcwd` が見つからない

`IUTEST_OS_MAC` が定義されている場合、次のようなコンパイルエラーが出ます。

``` cpp
impl/iutest_port.ipp:118:9: Use of undeclared identifier 'getcwd'
```

`iutest_port.hpp` 内の `#include <unistd.h>` が有効になっていなかったため `defined(IUTEST_OS_MAC)` を追加し、ビルドが通ることを確認しました:

``` cpp
#if defined(IUTEST_OS_LINUX) || defined(IUTEST_OS_CYGWIN) || defined(IUTEST_OS_MAC)
#  include <unistd.h>
#  include <locale.h>
#endif
```

ご確認のほど、よろしくお願いします。 :blush:
