### PR TITLE
Fix non-virtual destructors in classes with virtual functions

### DIFF
--- a/include/internal/iutest_console.hpp
+++ b/include/internal/iutest_console.hpp
@@ -47,6 +47,7 @@ namespace detail
 class iuLogger
 {
 public:
+	virtual ~iuLogger() IUTEST_CXX_DEFAULT_FUNCTION
 	virtual void output(const char* fmt, ...)
 	{
 		va_list va;

--- a/include/internal/iutest_mediator.hpp
+++ b/include/internal/iutest_mediator.hpp
@@ -38,6 +38,7 @@ protected:
 public:
 	iuITestInfoMediator(TestInfo* p=NULL) IUTEST_CXX_NOEXCEPT_SPEC : m_test_info(p) {}
 public:
+	virtual ~iuITestInfoMediator() IUTEST_CXX_DEFAULT_FUNCTION
 	virtual bool HasFatalFailure(void) const = 0;
 	virtual bool HasNonfatalFailure(void) const = 0;
 	virtual bool HasFailure(void) const = 0;
@@ -55,6 +56,7 @@ protected:
 public:
 	iuITestCaseMediator(TestCase* p=NULL) IUTEST_CXX_NOEXCEPT_SPEC : m_test_case(p) {}
 public:
+	virtual ~iuITestCaseMediator() IUTEST_CXX_DEFAULT_FUNCTION
 	virtual const char* test_case_name(void) const = 0;
 	virtual const char* type_param(void) const = 0;
 	TestCase* ptr(void) const IUTEST_CXX_NOEXCEPT_SPEC { return m_test_case; }

--- a/include/internal/iutest_params_util.hpp
+++ b/include/internal/iutest_params_util.hpp
@@ -43,6 +43,7 @@ public:
 	};
 public:
 	IParamTestInfoData(const char* name) : m_name(name) {}
+	virtual ~IParamTestInfoData() IUTEST_CXX_DEFAULT_FUNCTION
 	virtual TestCase* MakeTestCase(const char* , TestTypeId , SetUpMethod , TearDownMethod ) const = 0;
 	virtual EachTestBase* RegisterTest(TestCase* , const char* ) const = 0;
 	const char* GetName(void) const { return m_name.c_str(); }


### PR DESCRIPTION
こんにちは。

Xcode 7 (Apple LLVM) で iutest をコンパイルしたところ、次のような警告が出ました:
```
iutest_console.hpp:47:7: 'iutest::detail::iuLogger' has virtual functions but non-virtual destructor
iutest_mediator.hpp:34:7: 'iutest::detail::iuITestInfoMediator' has virtual functions but non-virtual destructor
iutest_mediator.hpp:51:7: 'iutest::detail::iuITestCaseMediator' has virtual functions but non-virtual destructor
iutest_params_util.hpp:34:7: 'iutest::detail::IParamTestInfoData' has virtual functions but non-virtual destructor
```

この PR では、仮想デストラクタを新たに追加して警告を修正しています。
よろしくお願いします。 :relieved: 