### PR TITLE
support msys2 mingw clang ( #8 )

### DIFF
--- a/include/impl/iutest_charcode.ipp
+++ b/include/impl/iutest_charcode.ipp
@@ -18,7 +18,11 @@
 //======================================================================
 // include
 #include "../internal/iutest_charcode.hpp"
-#if IUTEST_HAS_HDR_UCHAR
+
+//msys2 mingw clang predefine char16_t/char32_t. 
+//However, mingw's header try to redefine these so that clang make compile error.
+//When msys2 mingw clang doesn't define char16_t/char32_t, this line will case error.
+#if IUTEST_HAS_HDR_UCHAR && !(defined(__MINGW32__) && defined(_WIN32) && defined(__GNUC__) && defined(__clang__))
 #  include <uchar.h>
 #endif
 


### PR DESCRIPTION
#8 を修正します。

## 注意

clang は``char16_t``/``char32_t``型をclang2.9の時からサポートしています。
cf.) http://cpprefjp.github.io/implementation-status.html

ところで私はmsys2にclang2.9という古いバージョンを入れる方法を知らないので、
もしその頃のclangが``char16_t``/``char32_t``型をpredefineしなかった場合は**逆にコンパイルエラーに**なります。
