### PR TITLE
Fix -Wcomma compiler warnings

### DIFF
--- a/include/internal/iutest_genparams_from_file.hpp
+++ b/include/internal/iutest_genparams_from_file.hpp
@@ -76,7 +76,7 @@ private:
                 const ::std::string dataset = fp->ReadAll();
                 ::std::string::size_type prev = 0;
                 ::std::string::size_type pos = 0;
-                while( pos = dataset.find(delimiter, prev), pos != ::std::string::npos )
+                while( static_cast<void>(pos = dataset.find(delimiter, prev)), pos != ::std::string::npos )
                 {
                     const ::std::string data = dataset.substr(prev, pos - prev);
                     AppendParams(params, data);

--- a/include/internal/iutest_string.hpp
+++ b/include/internal/iutest_string.hpp
@@ -199,7 +199,7 @@ inline bool IsStringForwardMatching(const char* str1, const char* str2) { return
 inline void StringReplace(::std::string& str, char a, const char* to)
 {
     ::std::string::size_type pos = 0;
-    while( pos = str.find(a, pos), pos != ::std::string::npos )
+    while( static_cast<void>(pos = str.find(a, pos)), pos != ::std::string::npos )
     {
         str.replace(pos, 1, to);
         ++pos;
@@ -256,7 +256,7 @@ inline bool StringIsBlank(const ::std::string& str)
 inline void StringReplaceToLF(::std::string& str)
 {
     ::std::string::size_type pos = 0;
-    while( pos = str.find("\r\n", pos), pos != ::std::string::npos )
+    while( static_cast<void>(pos = str.find("\r\n", pos)), pos != ::std::string::npos )
     {
         str.replace(pos, 2, "\n");
         ++pos;
@@ -288,7 +288,7 @@ inline void StringSplit(const ::std::string& str, char delimiter, ::std::vector<
     ::std::string::size_type prev = 0;
     ::std::string::size_type pos = 0;
     ::std::vector< ::std::string > parsed;
-    while(pos = str.find(delimiter, prev), pos != ::std::string::npos)
+    while(static_cast<void>(pos = str.find(delimiter, prev)), pos != ::std::string::npos)
     {
         parsed.push_back(str.substr(prev, pos - prev));
         ++pos;


### PR DESCRIPTION
When compiling under Xcode 9.2 with Clang (Apple LLVM version 9.0.0), I get the following `-Wcomma` warnings:

```
In file included from iutest/include/internal/iutest_internal_defs.hpp:21:
iutest/include/internal/iutest_string.hpp:202:34: warning:
      possible misuse of comma operator here [-Wcomma]
    while( pos = str.find(a, pos), pos != ::std::string::npos )
                                 ^
iutest/include/internal/iutest_string.hpp:202:12: note: cast
      expression to void to silence warning
    while( pos = str.find(a, pos), pos != ::std::string::npos )
           ^~~~~~~~~~~~~~~~~~~~~~
           static_cast<void>(    )
iutest/include/internal/iutest_string.hpp:259:39: warning:
      possible misuse of comma operator here [-Wcomma]
    while( pos = str.find("\r\n", pos), pos != ::std::string::npos )
                                      ^
iutest/include/internal/iutest_string.hpp:259:12: note: cast
      expression to void to silence warning
    while( pos = str.find("\r\n", pos), pos != ::std::string::npos )
           ^~~~~~~~~~~~~~~~~~~~~~~~~~~
           static_cast<void>(         )
iutest/include/internal/iutest_string.hpp:291:42: warning:
      possible misuse of comma operator here [-Wcomma]
    while(pos = str.find(delimiter, prev), pos != ::std::string::npos)
                                         ^
iutest/include/internal/iutest_string.hpp:291:11: note: cast
      expression to void to silence warning
    while(pos = str.find(delimiter, prev), pos != ::std::string::npos)
          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          static_cast<void>(             )
In file included from iutest/include/gtest/iutest_switch.hpp:19:
In file included from iutest/include/gtest/iutest_switch_for_iutest.hpp:26:
In file included from iutest/include/gtest/../iutest.hpp:23:
In file included from iutest/include/iutest_core.hpp:22:
In file included from iutest/include/internal/iutest_params_util.hpp:21:
iutest/include/internal/iutest_genparams_from_file.hpp:79:59: warning:
      possible misuse of comma operator here [-Wcomma]
                while( pos = dataset.find(delimiter, prev), pos != ::std...
                                                          ^
iutest/include/internal/iutest_genparams_from_file.hpp:79:24: note:
      cast expression to void to silence warning
                while( pos = dataset.find(delimiter, prev), pos != ::std...
                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
                       static_cast<void>(                 )
4 warnings generated.
```

This pull request adds `static_cast<void>()` to fix them.
Thanks.