### PR TITLE
fix: avoid deprecated special function call

### DIFF
--- a/include/internal/iutest_list.hpp
+++ b/include/internal/iutest_list.hpp
@@ -69,7 +69,7 @@ public:
     iu_list_iterator(const iu_list_iterator& rhs) IUTEST_CXX_NOEXCEPT_SPEC : m_node(rhs.m_node) {}
     iu_list_iterator& operator = (const iu_list_iterator& rhs) IUTEST_CXX_NOEXCEPT_SPEC
     {
-        m_node = rhs.rhs;
+        m_node = rhs.m_node;
         return *this;
     }
 

--- a/include/internal/iutest_list.hpp
+++ b/include/internal/iutest_list.hpp
@@ -70,6 +70,7 @@ public:
     iu_list_iterator& operator = (const iu_list_iterator& rhs) IUTEST_CXX_NOEXCEPT_SPEC
     {
         m_node = rhs.rhs;
+        return *this;
     }
 
 public:

--- a/include/internal/iutest_list.hpp
+++ b/include/internal/iutest_list.hpp
@@ -67,6 +67,10 @@ public:
 public:
     iu_list_iterator(value_ptr p=NULL) IUTEST_CXX_NOEXCEPT_SPEC : m_node(p) {}  // NOLINT
     iu_list_iterator(const iu_list_iterator& rhs) IUTEST_CXX_NOEXCEPT_SPEC : m_node(rhs.m_node) {}
+    iu_list_iterator& operator = (const iu_list_iterator& rhs) IUTEST_CXX_NOEXCEPT_SPEC
+    {
+        m_node = rhs.rhs;
+    }
 
 public:
     bool operator == (const _Myt& it) const { return this->m_node == it.m_node; }

--- a/include/internal/iutest_regex.hpp
+++ b/include/internal/iutest_regex.hpp
@@ -46,6 +46,7 @@ class iuRegex
 public:
     iuRegex(const char* pattern) { Init(pattern); }                     // NOLINT
     iuRegex(const ::std::string& pattern) { Init(pattern.c_str()); }    // NOLINT
+    iuRegex(const iuRegex & rhs) : m_re(rhs.m_re), m_pattern(rhs.m_pattern) {}
 public:
     bool FullMatch(const char* str) const;
     bool PartialMatch(const char* str) const;

--- a/include/iutest_matcher.hpp
+++ b/include/iutest_matcher.hpp
@@ -65,6 +65,8 @@ public:
     template<typename T>
     struct is_matcher : public iutest_type_traits::is_base_of<IMatcher, T> {};
 public:
+    // IMatcher(const IMatcher &) {}
+    IMatcher& operator = (const IMatcher&) { return *this; }
     virtual ~IMatcher() {}
     virtual ::std::string WhichIs() const = 0;
 };
@@ -82,6 +84,7 @@ inline iu_ostream& operator << (iu_ostream& os, const IMatcher& msg)
 #define DECL_COMPARE_MATCHER(name, op)  \
     template<typename T>class IUTEST_PP_CAT(name, Matcher): public IMatcher{    \
     public: explicit IUTEST_PP_CAT(name, Matcher)(const T& v) : m_expected(v) {}\
+    IUTEST_PP_CAT(name, Matcher)(const IUTEST_PP_CAT(name, Matcher) & rhs) : m_expected(rhs.m_expected) {}\
     ::std::string WhichIs() const IUTEST_CXX_OVERRIDE {                         \
         iu_global_format_stringstream strm;                                     \
         strm << #name ": " << m_expected; return strm.str();                    \
@@ -97,6 +100,7 @@ inline iu_ostream& operator << (iu_ostream& os, const IMatcher& msg)
 #define DECL_COMPARE_MATCHER2(name, op) \
     class IUTEST_PP_CAT(Twofold, IUTEST_PP_CAT(name, Matcher)): public IMatcher{        \
     public: IUTEST_PP_CAT(Twofold, IUTEST_PP_CAT(name, Matcher))() {}                   \
+    IUTEST_PP_CAT(Twofold, IUTEST_PP_CAT(name, Matcher))(const IUTEST_PP_CAT(Twofold, IUTEST_PP_CAT(name, Matcher)) &) {}\
     ::std::string WhichIs() const IUTEST_CXX_OVERRIDE { return #name; }                 \
     template<typename T, typename U>AssertionResult operator ()                         \
         (const T& actual, const U& expected) const {                                    \
@@ -1453,6 +1457,7 @@ class AnyMatcher : public IMatcher
 {
 public:
     AnyMatcher() {}
+    AnyMatcher(const AnyMatcher &) {}
 public:
     AssertionResult operator ()(const T&) const
     {
@@ -1479,6 +1484,7 @@ class AnythingMatcher : public IMatcher
 {
 public:
     AnythingMatcher() {}
+    AnythingMatcher(const AnythingMatcher &) {}
 public:
     template<typename U>
     AssertionResult operator ()(const U&) const

--- a/include/iutest_matcher.hpp
+++ b/include/iutest_matcher.hpp
@@ -332,7 +332,7 @@ class HasSubstrMatcher : public IMatcher
 {
 public:
     explicit HasSubstrMatcher(T expected) : m_expected(expected) {}
-
+    HasSubstrMatcher(const HasSubstrMatcher & rhs) : m_expected(rhs.m_expected) {}
 public:
     template<typename U>
     AssertionResult operator ()(const U& actual) const


### PR DESCRIPTION
when copy ctor/assign op is user-provided,
calling copy assign op/ctor is deprecated in C++11 or later.

ref:
- http://d.hatena.ne.jp/yohhoy/20140704/p1