### PR TITLE
Fix -Wnon-virtual-dtor warning on Clang

### DIFF
--- a/include/iutest_matcher.hpp
+++ b/include/iutest_matcher.hpp
@@ -63,10 +63,14 @@ IUTEST_PRAGMA_ASSIGNMENT_OPERATOR_COULD_NOT_GENERATE_WARN_DISABLE_BEGIN()
 */
 class IMatcher
 {
+    IMatcher& operator=(const IMatcher&);
 public:
     template<typename T>
     struct is_matcher : public iutest_type_traits::is_base_of<IMatcher, T> {};
 public:
+    IMatcher() {}
+    IMatcher(const IMatcher&) {}
+    virtual ~IMatcher() {}
     virtual ::std::string WhichIs() const = 0;
 };
 


### PR DESCRIPTION
Hi, I get the following warning when I use with the `-Wnon-virtual-dtor` option in Clang 6.0 and this change fixes it.
```
iutest/include/iutest_matcher.hpp:233:7: error:
      'iutest::detail::NanSensitiveFloatingPointEqMatcher<double>' has virtual functions but non-virtual destructor
      [-Werror,-Wnon-virtual-dtor]
class NanSensitiveFloatingPointEqMatcher : public IMatcher
      ^
```

Thank you for reviewing https://github.com/srz-zumix/iutest/pull/86 👍 