### PR TITLE
iuwandbox json decode error

### DIFF
--- a/tools/wandbox/wandbox.py
+++ b/tools/wandbox/wandbox.py
@@ -69,7 +69,10 @@ class Wandbox:
         payload = json.dumps(self.parameter)
         response = requests.post(self.api_url + '/compile.json', data=payload, headers=headers)
         response.raise_for_status()
-        return response.json()
+        try:
+            return response.json()
+        except json.decoder.JSONDecodeError as e:
+            raise requests.exceptions.HTTPError(e, response.status_code)
 
     def code(self, code):
         """


### PR DESCRIPTION
fix: able to retry

```
 File "./iuwandbox.py", line 490, in run
    return w.run()
  File "/root/src/github.com/srz-zumix/iutest/tools/wandbox/wandbox.py", line 72, in run
    return response.json()
  File "/root/venv/3.7/lib/python3.7/site-packages/requests/models.py", line 898, in json
    return complexjson.loads(self.text, **kwargs)
  File "/usr/local/lib/python3.7/json/__init__.py", line 348, in loads
    return _default_decoder.decode(s)
  File "/usr/local/lib/python3.7/json/decoder.py", line 337, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
  File "/usr/local/lib/python3.7/json/decoder.py", line 355, in raw_decode
    raise JSONDecodeError("Expecting value", s, err.value) from None
json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
```