### PR TITLE
codeship pro to basic

### DIFF
--- a/.ci/codeship/test.sh
+++ b/.ci/codeship/test.sh
@@ -5,11 +5,11 @@ doxygen --version
 python --version
 export GH_PAGES_BRANCH=0
 if echo "$CI_BRANCH" | grep -q "gh-pages"; then export GH_PAGES_BRANCH=1; fi
-if [ $GH_PAGES_BRANCH == 0 ]; then make -C test/cpplint; fi
-if [ $GH_PAGES_BRANCH == 0 ]; then make -C test check_incg; fi
-if [ $GH_PAGES_BRANCH == 0 ]; then ! find projects -type f -print | xargs grep '[d-zD-Z]:\\'; fi
-if [ $GH_PAGES_BRANCH == 0 ]; then make -C test/docs version-test; fi
-if [ $GH_PAGES_BRANCH == 0 ]; then make -C test/docs doxygen-test; fi
-if [ $GH_PAGES_BRANCH == 0 ]; then sh .ci/check-crlf.sh; fi
-if [ $GH_PAGES_BRANCH == 0 ]; then make editorconfig-self-lint; fi
+if [ "$GH_PAGES_BRANCH" = 0 ]; then make -C test/cpplint; fi
+if [ "$GH_PAGES_BRANCH" = 0 ]; then make -C test check_incg; fi
+if [ "$GH_PAGES_BRANCH" = 0 ]; then ! find projects -type f -print | xargs grep '[d-zD-Z]:\\'; fi
+if [ "$GH_PAGES_BRANCH" = 0 ]; then make -C test/docs version-test; fi
+if [ "$GH_PAGES_BRANCH" = 0 ]; then make -C test/docs doxygen-test; fi
+if [ "$GH_PAGES_BRANCH" = 0 ]; then sh .ci/check-crlf.sh; fi
+if [ "$GH_PAGES_BRANCH" = 0 ]; then make editorconfig-self-lint; fi
 if git grep --cached -I -l -P '\r'; then exit 1; fi

--- a/.ci/codeship/test.sh
+++ b/.ci/codeship/test.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+#cat /etc/lsb-release
+doxygen --version
+python --version
+export GH_PAGES_BRANCH=0
+if echo "$CI_BRANCH" | grep -q "gh-pages"; then export GH_PAGES_BRANCH=1; fi
+if [ $GH_PAGES_BRANCH == 0 ]; then make -C test/cpplint; fi
+if [ $GH_PAGES_BRANCH == 0 ]; then make -C test check_incg; fi
+if [ $GH_PAGES_BRANCH == 0 ]; then ! find projects -type f -print | xargs grep '[d-zD-Z]:\\'; fi
+if [ $GH_PAGES_BRANCH == 0 ]; then make -C test/docs version-test; fi
+if [ $GH_PAGES_BRANCH == 0 ]; then make -C test/docs doxygen-test; fi
+if [ $GH_PAGES_BRANCH == 0 ]; then sh .ci/check-crlf.sh; fi
+if [ $GH_PAGES_BRANCH == 0 ]; then make editorconfig-self-lint; fi
+if git grep --cached -I -l -P '\r'; then exit 1; fi

--- a/.ci/codeship/test.sh
+++ b/.ci/codeship/test.sh
@@ -1,15 +1,36 @@
 #!/bin/bash
+# Codeship Test Console Setting
+# ==============================================================================
+# doxygen --version
+# python --version
+# export GH_PAGES_BRANCH=0
+# if echo "$CI_BRANCH" | grep -q "gh-pages"; then export GH_PAGES_BRANCH=1; fi
+# if [ $GH_PAGES_BRANCH == 0 ]; then make -C test/cpplint; fi
+# if [ $GH_PAGES_BRANCH == 0 ]; then make -C test check_incg; fi
+# if [ $GH_PAGES_BRANCH == 0 ]; then ! find projects -type f -print0 | xargs -0 grep '[d-zD-Z]:\\'; fi
+# if [ $GH_PAGES_BRANCH == 0 ]; then make -C test/docs version-test; fi
+# if [ $GH_PAGES_BRANCH == 0 ]; then make -C test/docs doxygen-test; fi
+# if [ $GH_PAGES_BRANCH == 0 ]; then sh .ci/check-crlf.sh; fi
+# if [ $GH_PAGES_BRANCH == 0 ]; then make editorconfig-self-lint; fi
+# if git grep --cached -I -l -P '\r'; then exit 1; fi
+# ==============================================================================
 
-#cat /etc/lsb-release
 doxygen --version
 python --version
 export GH_PAGES_BRANCH=0
-if echo "$CI_BRANCH" | grep -q "gh-pages"; then export GH_PAGES_BRANCH=1; fi
-if [ "$GH_PAGES_BRANCH" = 0 ]; then make -C test/cpplint; fi
-if [ "$GH_PAGES_BRANCH" = 0 ]; then make -C test check_incg; fi
-if [ "$GH_PAGES_BRANCH" = 0 ]; then ! find projects -type f -print | xargs grep '[d-zD-Z]:\\'; fi
-if [ "$GH_PAGES_BRANCH" = 0 ]; then make -C test/docs version-test; fi
-if [ "$GH_PAGES_BRANCH" = 0 ]; then make -C test/docs doxygen-test; fi
-if [ "$GH_PAGES_BRANCH" = 0 ]; then sh .ci/check-crlf.sh; fi
-if [ "$GH_PAGES_BRANCH" = 0 ]; then make editorconfig-self-lint; fi
-if git grep --cached -I -l -P '\r'; then exit 1; fi
+if echo "$CI_BRANCH" | grep -q "gh-pages"; then
+  export GH_PAGES_BRANCH=1;
+fi
+if [ "$GH_PAGES_BRANCH" = 0 ]; then
+  echo
+  make -C test/cpplint
+  make -C test check_incg
+  ! find projects -type f -print0 | xargs -0 grep '[d-zD-Z]:\\'
+  make -C test/docs version-test
+  make -C test/docs doxygen-test
+  sh .ci/check-crlf.sh
+  make editorconfig-self-lint
+fi
+if git grep --cached -I -l -P '\r'; then
+  exit 1
+fi

--- a/.ci/codeship/test.sh
+++ b/.ci/codeship/test.sh
@@ -7,7 +7,7 @@
 # if echo "$CI_BRANCH" | grep -q "gh-pages"; then export GH_PAGES_BRANCH=1; fi
 # if [ $GH_PAGES_BRANCH == 0 ]; then make -C test/cpplint; fi
 # if [ $GH_PAGES_BRANCH == 0 ]; then make -C test check_incg; fi
-# if [ $GH_PAGES_BRANCH == 0 ]; then ! find projects -type f -print0 | xargs -0 grep '[d-zD-Z]:\\'; fi
+# if [ $GH_PAGES_BRANCH == 0 ]; then ! find projects -type f -print0 | xargs -0 grep '[d-zD-Z]:\\.*'; fi
 # if [ $GH_PAGES_BRANCH == 0 ]; then make -C test/docs version-test; fi
 # if [ $GH_PAGES_BRANCH == 0 ]; then make -C test/docs doxygen-test; fi
 # if [ $GH_PAGES_BRANCH == 0 ]; then sh .ci/check-crlf.sh; fi

--- a/.ci/sync-svn.sh
+++ b/.ci/sync-svn.sh
@@ -1,9 +1,5 @@
 #!/bin/bash
 
-# .ssh/config
-ssh-keyscan -H "svn.osdn.jp" >> ~/.ssh/known_hosts
-ssh-keyscan -H "github.com" >> ~/.ssh/known_hosts
-
 svn --version
 svn co svn+ssh://srz_zumix@svn.osdn.jp/svnroot/iutest/trunk svn
 git clone git@github.com:srz-zumix/iutest.git git-svn

--- a/.ci/sync-svn.sh
+++ b/.ci/sync-svn.sh
@@ -1,13 +1,8 @@
 #!/bin/bash
 
 # .ssh/config
-echo "host svn.osdn.jp" >> ~/.ssh/config && \
-echo "  StrictHostKeyChecking no" >> ~/.ssh/config && \
-echo "host github.com" >> ~/.ssh/config && \
-echo "  StrictHostKeyChecking no" >> ~/.ssh/config && \
-chmod 600 ~/.ssh/config
-
-ls ~/.ssh/
+ssh-keyscan -H "svn.osdn.jp" >> ~/.ssh/known_hosts
+ssh-keyscan -H "github.com" >> ~/.ssh/known_hosts
 
 svn --version
 svn co svn+ssh://srz_zumix@svn.osdn.jp/svnroot/iutest/trunk svn

--- a/.ci/sync-svn.sh
+++ b/.ci/sync-svn.sh
@@ -1,5 +1,12 @@
 #!/bin/bash
 
+# .ssh/config
+echo "host svn.osdn.jp" >> ~/.ssh/config && \
+echo "  StrictHostKeyChecking no" >> ~/.ssh/config && \
+echo "host github.com" >> ~/.ssh/config && \
+echo "  StrictHostKeyChecking no" >> ~/.ssh/config && \
+chmod 600 ~/.ssh/config
+
 svn --version
 svn co svn+ssh://srz_zumix@svn.osdn.jp/svnroot/iutest/trunk svn
 git clone git@github.com:srz-zumix/iutest.git git-svn

--- a/.ci/sync-svn.sh
+++ b/.ci/sync-svn.sh
@@ -7,6 +7,8 @@ echo "host github.com" >> ~/.ssh/config && \
 echo "  StrictHostKeyChecking no" >> ~/.ssh/config && \
 chmod 600 ~/.ssh/config
 
+ls ~/.ssh/
+
 svn --version
 svn co svn+ssh://srz_zumix@svn.osdn.jp/svnroot/iutest/trunk svn
 git clone git@github.com:srz-zumix/iutest.git git-svn

--- a/codeship-services.yml
+++ b/codeship-services.yml
@@ -3,5 +3,6 @@ iutest:
     image: codeship/iutest
     dockerfile: ./tools/docker/Dockerfile
   volumes:
+    - ./.ssh:/root/.ssh
     - ./:/work
   cached: true

--- a/codeship-steps.yml
+++ b/codeship-steps.yml
@@ -28,7 +28,6 @@
       command: make -C /work/test/repository check-remote-crlf
 
 - type: parallel
-  tag: master
   steps:
     - name: sync-svn
       service: iutest

--- a/codeship-steps.yml
+++ b/codeship-steps.yml
@@ -1,3 +1,5 @@
+# iutest using codeship basic
+# this file is codeship settings sample
 - type: parallel
   exclude: gh-pages
   steps:
@@ -28,7 +30,7 @@
       command: make -C /work/test/repository check-remote-crlf
 
 - type: parallel
-  exclude: gh-pages
+  tag: master
   steps:
     - name: sync-svn
       service: iutest

--- a/codeship-steps.yml
+++ b/codeship-steps.yml
@@ -28,6 +28,7 @@
       command: make -C /work/test/repository check-remote-crlf
 
 - type: parallel
+  exclude: gh-pages
   steps:
     - name: sync-svn
       service: iutest

--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -68,15 +68,6 @@ RUN . /etc/os-release && \
     update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-${CLANG_VERSION} 1000 \
                         --slave   /usr/bin/clang clang /usr/bin/clang-${CLANG_VERSION}
 
-# .ssh/config
-
-RUN mkdir ~/.ssh ; \
-    echo "host svn.osdn.jp" >> ~/.ssh/config && \
-    echo "  StrictHostKeyChecking no" >> ~/.ssh/config && \
-    echo "host github.com" >> ~/.ssh/config && \
-    echo "  StrictHostKeyChecking no" >> ~/.ssh/config && \
-    chmod 600 ~/.ssh/config
-
 RUN mkdir /iutest
 VOLUME [ "/iutest" ]
 WORKDIR /iutest


### PR DESCRIPTION
SSH Key の管理がめんどくさいのでデフォルトでプロジェクトの SSH Key が使える Basic に戻します。