### PR TITLE
fix(fs): junction doesn't exist on mingw

### DIFF
--- a/include/iutest_printers.hpp
+++ b/include/iutest_printers.hpp
@@ -450,7 +450,7 @@ inline ::std::string FileSystemFileTypeToString(const ::std::filesystem::file_ty
     IUTEST_PP_NAMESPACE_ENUM_CASE_RETURN_STRING(::std::filesystem::file_type, fifo);
     IUTEST_PP_NAMESPACE_ENUM_CASE_RETURN_STRING(::std::filesystem::file_type, socket);
     IUTEST_PP_NAMESPACE_ENUM_CASE_RETURN_STRING(::std::filesystem::file_type, unknown);
-#if defined(IUTEST_OS_WINDOWS)
+#if defined(IUTEST_OS_WINDOWS) && !defined(IUTEST_OS_WINDOWS_MINGW)
     IUTEST_PP_NAMESPACE_ENUM_CASE_RETURN_STRING(::std::filesystem::file_type, junction);
 #endif
     default:


### PR DESCRIPTION
fix  #473